### PR TITLE
Fix cross-platform build

### DIFF
--- a/CefGlue.Client/CefGlue.Client.csproj
+++ b/CefGlue.Client/CefGlue.Client.csproj
@@ -9,6 +9,9 @@
     <UseWindowsForms>true</UseWindowsForms>
 
     <ApplicationManifest>app.manifest</ApplicationManifest>
+
+    <!-- Required for building with .NET SDK 8+ when resources contain non-string types -->
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,6 +30,14 @@
       <DependentUpon>MainForm.cs</DependentUpon>
     </EmbeddedResource>
   </ItemGroup>
+
+  <!-- Reference System.Resources.Extensions from the local .NET SDK to avoid network dependency -->
+  <ItemGroup>
+    <Reference Include="System.Resources.Extensions">
+      <HintPath>$(MSBuildSDKsPath)/../System.Resources.Extensions.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
   <ItemGroup>
     <None Include="app.config" />
     <None Include="app.manifest" />

--- a/CefGlue.Samples.WpfOsr/CefGlue.Samples.WpfOsr.csproj
+++ b/CefGlue.Samples.WpfOsr/CefGlue.Samples.WpfOsr.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
 
+    <!-- Allow building this Windows-targeted sample on non-Windows agents -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+
     <OutputType>WinExe</OutputType>
     <AssemblyName>Xilium.Samples.WpfOsr</AssemblyName>
     <RootNamespace>Xilium.Samples.WpfOsr</RootNamespace>

--- a/CefGlue.WPF/CefGlue.WPF.csproj
+++ b/CefGlue.WPF/CefGlue.WPF.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net5.0-windows</TargetFramework>
 
+    <!-- Allow building this Windows-targeted project on non-Windows agents -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+
     <AssemblyName>Xilium.CefGlue.WPF</AssemblyName>
     <RootNamespace>Xilium.CefGlue.WPF</RootNamespace>
 


### PR DESCRIPTION
## Summary
- enable Windows-targeted projects to build on Linux
- fix resource generation error by referencing System.Resources.Extensions from the SDK

## Testing
- `dotnet build Xilium.CefGlue.sln -c Release`