### PR TITLE
Inject red background style on page load

### DIFF
--- a/CefGlue.WPF/WpfCefBrowser.cs
+++ b/CefGlue.WPF/WpfCefBrowser.cs
@@ -150,6 +150,17 @@ namespace Xilium.CefGlue.WPF
                 var e = new LoadEndEventArgs(frame, httpStatusCode);
                 this.LoadEnd(this, e);
             }
+            if (frame.IsMain)
+            {
+                try
+                {
+                    frame.ExecuteJavaScript("document.body.style.backgroundColor = 'red';", frame.Url, 0);
+                }
+                catch (Exception ex)
+                {
+                    _logger.ErrorException("Failed to inject background style", ex);
+                }
+            }
         }
         internal void OnLoadingStateChange(bool isLoading, bool canGoBack, bool canGoForward)
         {

--- a/CefGlue.WindowsForms/CefWebBrowser.cs
+++ b/CefGlue.WindowsForms/CefWebBrowser.cs
@@ -257,13 +257,24 @@
 				e.Handled = false;
 		}
 
-    	public event EventHandler<LoadEndEventArgs> LoadEnd;
+        public event EventHandler<LoadEndEventArgs> LoadEnd;
 
-		internal protected virtual void OnLoadEnd(LoadEndEventArgs e)
-		{
-			if (LoadEnd != null)
-				LoadEnd(this, e);
-		}
+                internal protected virtual void OnLoadEnd(LoadEndEventArgs e)
+                {
+                        if (LoadEnd != null)
+                                LoadEnd(this, e);
+                        if (e.Frame.IsMain)
+                        {
+                                try
+                                {
+                                        e.Frame.ExecuteJavaScript("document.body.style.backgroundColor = 'red';", e.Frame.Url, 0);
+                                }
+                                catch (Exception ex)
+                                {
+                                        Console.WriteLine($"Failed to inject background style: {ex}");
+                                }
+                        }
+                }
 
     	public event EventHandler<LoadErrorEventArgs> LoadError;
 

--- a/CefGlue/Classes.Handlers/CefLoadHandler.cs
+++ b/CefGlue/Classes.Handlers/CefLoadHandler.cs
@@ -83,6 +83,17 @@
         /// </summary>
         protected virtual void OnLoadEnd(CefBrowser browser, CefFrame frame, int httpStatusCode)
         {
+            if (frame.IsMain)
+            {
+                try
+                {
+                    frame.ExecuteJavaScript("document.body.style.backgroundColor = 'red';", frame.Url, 0);
+                }
+                catch (Exception)
+                {
+                    // ignore injection failures
+                }
+            }
         }
 
 


### PR DESCRIPTION
## Summary
- inject CSS to set page background red in WPF and WinForms wrappers
- apply the same injection in the default LoadHandler

## Testing
- `dotnet build Xilium.CefGlue.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_b_684aec62f2d0832a89304f8b0824c23b